### PR TITLE
Fix cache broken by datasets.copy()

### DIFF
--- a/ProfileLikelihoodRatio.py
+++ b/ProfileLikelihoodRatio.py
@@ -165,6 +165,7 @@ class LRBase(ECPLiBase):
             self._logger.debug(info)
 
         datasets = self.datasets.copy()
+        datasets.models = datasets.models #reset the lru_cache broken by copy
 
         if parameter_value is not None:
             freeze_target_parameter(frozen=True)


### PR DESCRIPTION
Reset models to reset lru_cache on dataset.evaluators  broken by datasets.copy()
